### PR TITLE
Feature rerquest: allow search from hasPrefix or substring

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -73,9 +73,12 @@ func getCompletionCandidates(
 		for _, match := range matches {
 			value := line[match[0]:match[1]]
 
-			if !strings.HasPrefix(value, identifier.Value) {
+			if !strings.Contains(value, identifier.Value) {
 				continue
 			}
+			//		if !strings.HasPrefix(value, identifier.Value) {
+			//			continue
+			//		}
 
 			if value == identifier.Value {
 				continue


### PR DESCRIPTION
Hi
I wanted this to have the ability to autocomplete a word based on a substring rather than the beginning of a word.  An example:

Let's assume I have the following text in the tmux window:
```
someserver.example.com
another.example.com
bob.example.com
```

I want to be able to type "example" and pick from the three matching words/server fqdns.

I would have implemented this as an extra command-line argument to allow you to pick which match method you want, but I haven't worked out how to do that yet.